### PR TITLE
Add dupe_metadata.py and scripts/bin/access_beagle_endpoint.py

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,5 @@
+## deregister_jobs_and_files.py
+
 This will retrieve runs and files associated with a `request_id` and then builds a bash script that, when executed, will delete jobs through `beaglecli`
 
 Prerequisite:
@@ -22,3 +24,28 @@ For example:
 python3 deregister_jobs_and_files.py 09603_I execute.sh
 bash execute.sh
 ```
+
+## dupe_metadata.py
+
+The dupe_metadata.py script is a utility for duplicating files and their metadata from one filegroup slug to another within Beagle AI's endpoint. It takes source and destination filegroup slugs, a request ID, and optional key-value pairs as arguments. The script retrieves the file IDs for the given request and source slug, fetches the corresponding file metadata (including type and path), updates it with any provided additional metadata, and then copies it over to the destination filegroup slug.
+
+This is useful when you need to replicate files and their associated data while adding or modifying specific metadata attributes in Beagle AI's environment.
+
+Assumptions:
+
+- Destination filegroup slug must exist.
+- `BEAGLE_ENDPOINT`, `BEAGLE_USER`, and `BEAGLE_PW` env vars are set.
+
+Usage:
+
+Here's a usage example for `dupe_metadata.py`:
+
+```
+python scripts/dupe_metadata.py --source_slug lims --dest_slug destination-files --request_id 12345 --kwargs runId=ABCD_123 runMode="XSeq"
+```
+
+In this command:
+- `lims` is the filegroup slug from which files are to be copied.
+- `tmp-fg` is the filegroup slug to which files should be copied.
+- `12345` is the ID of the request for which the files belong.
+- `runId=ABCD_123 runMode="XSeq"` are optional key-value pairs that can be added as metadata when copying files.

--- a/scripts/bin/access_beagle_endpoint.py
+++ b/scripts/bin/access_beagle_endpoint.py
@@ -31,6 +31,26 @@ class AccessBeagleEndpoint:
         print(f"Status {req.status_code}")
         return req
 
+#    def post_url(self, url, payload):
+#        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+#        try:
+#            response = requests.post(
+#                url, auth=self.auth, verify=False, json=payload, headers=headers
+#            )
+#            if not response.ok:
+#                raise RuntimeError(f"POST failed: {response.status_code} {response.text}")
+#        except RuntimeError as e:
+#            print(f"An error occurred during the POST request: {e}")
+
+
+    def put_url(self, url, payload):
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        response = requests.put(
+            url + "/", auth=self.auth, verify=False, json=payload, headers=headers
+        )
+        if not response.ok:
+            raise RuntimeError(f"PUT failed: {response.status_code} {response.text}")
+
     # had to build url weird because the requests docs were busted and I kept running into issues
     def get_etl_jobs_by_request(self, request_id):
         url = "%s/v0/etl/jobs/?page_size=1000&request_id=%s" % (self.API, request_id)
@@ -40,21 +60,71 @@ class AccessBeagleEndpoint:
         url = "%s/v0/etl/jobs/%s" % (self.API, run_id)
         return self.run_url(url)
 
-    def get_file_ids(self, request_id):
-        url = "%s/v0/fs/files/?page_size=1000&metadata=igoRequestId:%s" % (self.API, request_id)
+    def get_file_ids(self, request_id, fg_slug="lims"):
+        fg = self.get_file_group_id_by_slug(fg_slug)
+        url = (
+            "%s/v0/fs/files/?file_group=%s&page_size=1000&metadata=igoRequestId:%s"
+            % (
+                self.API,
+                fg,
+                request_id,
+            )
+        )
         data = self.run_url(url)
         file_ids = list()
-        for result in data['results']:
-            file_ids.append(result['id'])
+        for result in data["results"]:
+            file_ids.append(result["id"])
         return file_ids
 
-    def get_file_id_by_path(self, path):
-        url = "%s/v0/fs/files/?page_size=1000&path=%s" % (self.API, path)
-        data = self.run_url(url)['results']
+    def get_file_id_by_path(self, path, fg_slug="lims"):
+        fg = self.get_file_group_id_by_slug(fg_slug)
+        url = "%s/v0/fs/files/?file_group=%s&page_size=1000&path=%s" % (
+            self.API,
+            fg,
+            path,
+        )
+        data = self.run_url(url)["results"]
         if len(data) > 1:
             print("Error retrieving file_id by path; multiple entries found")
-        if 'id' in data:
-            return data['id']
+        if "id" in data:
+            return data["id"]
+
+    def get_storage_all(self):
+        url = "%s/v0/fs/storage/" % self.API
+        data = self.run_url(url)["results"]
+        return data
+
+    def get_storage_id_by_name(self, name):
+        storage_all = self.get_storage_all()
+        for i in storage_all:
+            storage_name = i["name"]
+            if storage_name == name:
+                return i["id"]
+        return None
+
+    def get_file_group_id_by_slug(self, s):
+        url = "%s/v0/fs/file-groups/%s" % (self.API, s)
+        response = self.run_url(url)
+        if response.get("detail") == "Not found.":
+            pass
+        else:
+            id_value = response["id"]
+            return id_value
+
+    def put_metadata_into_file(self, file_id, metadata):
+        url = "%s/v0/fs/files/%s" % (self.API, file_id)
+        payload = {"metadata": metadata}
+        self.put_url(url, payload)
+
+    def post_file_to_filegroup(self, path, file_type, metadata, file_group):
+        url = "%s/v0/fs/files/" % (self.API)
+        payload = {"path": path, "file_type": file_type, "metadata": metadata, "file_group": file_group}
+        self.post_url(url, payload)
+
+    def get_file_metadata(self, file_id):
+        url = "%s/v0/fs/files/%s" % (self.API, file_id)
+        data = self.run_url(url)
+        return data
 
     def get_files_by_metadata(self, key_val, file_group):
         url = f"{self.API}/v0/fs/files/?metadata={key_val}&file_group={file_group}&page_size=1000"

--- a/scripts/bin/access_beagle_endpoint.py
+++ b/scripts/bin/access_beagle_endpoint.py
@@ -31,18 +31,6 @@ class AccessBeagleEndpoint:
         print(f"Status {req.status_code}")
         return req
 
-#    def post_url(self, url, payload):
-#        headers = {"Accept": "application/json", "Content-Type": "application/json"}
-#        try:
-#            response = requests.post(
-#                url, auth=self.auth, verify=False, json=payload, headers=headers
-#            )
-#            if not response.ok:
-#                raise RuntimeError(f"POST failed: {response.status_code} {response.text}")
-#        except RuntimeError as e:
-#            print(f"An error occurred during the POST request: {e}")
-
-
     def put_url(self, url, payload):
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         response = requests.put(

--- a/scripts/dupe_metadata.py
+++ b/scripts/dupe_metadata.py
@@ -1,0 +1,39 @@
+import os
+import argparse
+from dotenv import load_dotenv
+from bin.access_beagle_endpoint import AccessBeagleEndpoint
+
+# Load environment variables from .env file
+load_dotenv()
+
+def dupe_files(source_slug, dest_slug, request_id, **kwargs):
+    endpoint = AccessBeagleEndpoint()
+    file_ids = endpoint.get_file_ids(request_id, source_slug)
+
+    # For every file_id and its metadata, copy it over into dest_slug
+    for file_id in file_ids:
+        file_meta = endpoint.get_file_metadata(file_id)
+        file_type = file_meta["file_type"]
+        file_path = file_meta["path"]
+        file_metadata = file_meta["metadata"]
+
+        file_metadata.update(kwargs)
+        file_group_id = endpoint.get_file_group_id_by_slug(dest_slug)
+        print(f"Adding {file_path} to file group {dest_slug}.")
+        endpoint.post_file_to_filegroup(path=file_path,file_type=file_type,metadata=file_metadata,file_group=file_group_id)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source_slug", help="Filegroup source slug")
+    parser.add_argument("--dest_slug", help="Filegroup destination slug")
+    parser.add_argument("--request_id", help="Request ID")
+    parser.add_argument("--kwargs", nargs="+", default=[], help="Optional key-value pairs to add as metadata (e.g., --kwargs key1=val1 key2=val2)")
+    args = parser.parse_args()
+
+    # Convert optional kwargs string list into a dictionary
+    kwargs = {}
+    for kwarg in args.kwargs:
+        key, value = kwarg.split("=")
+        kwargs[key] = value
+
+    dupe_files(args.source_slug, args.dest_slug, args.request_id, **kwargs)

--- a/scripts/dupe_metadata.py
+++ b/scripts/dupe_metadata.py
@@ -1,10 +1,6 @@
 import os
 import argparse
-from dotenv import load_dotenv
 from bin.access_beagle_endpoint import AccessBeagleEndpoint
-
-# Load environment variables from .env file
-load_dotenv()
 
 def dupe_files(source_slug, dest_slug, request_id, **kwargs):
     endpoint = AccessBeagleEndpoint()


### PR DESCRIPTION
 Add `dupe_metadata.py` script, update access endpoint logic and clean up README.
 
 Impact
- Provides a new utility to duplicate files between file groups.
- Enhances the `AccessBeagleEndpoint` with updated request handling and metadata formatting.
- Minor documentation updates in README.
